### PR TITLE
`IconButtonProps` interface extends change in `@igloo-ui/icon-button`

### DIFF
--- a/.changeset/stale-parrots-admire.md
+++ b/.changeset/stale-parrots-admire.md
@@ -1,0 +1,5 @@
+---
+'@igloo-ui/icon-button': minor
+---
+
+Change IconButtonProps extends to use ButtonProps

--- a/packages/IconButton/package.json
+++ b/packages/IconButton/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "@igloo-ui/tokens": "^1.1.0",
-    "@igloo-ui/button": "^0.1.4",
+    "@igloo-ui/button": "^0.1.6",
     "classnames": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/IconButton/src/IconButton.stories.tsx
+++ b/packages/IconButton/src/IconButton.stories.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Meta } from '@storybook/react';
 
-import IconButton from './IconButton';
-import { Props, Appearance } from '@igloo-ui/button';
+import IconButton, { IconButtonProps } from './IconButton';
+import { Appearance } from '@igloo-ui/button';
 
 import Plus from '@igloo-ui/icons/dist/Plus';
 import Settings from '@igloo-ui/icons/dist/Settings';
@@ -15,7 +15,12 @@ export default {
 
 interface TemplateProps {
   appearance?: Appearance;
-  payload: { base: Props[]; disabled: Props[]; active: Props[] };
+  payload: {
+    base: IconButtonProps[];
+    disabled: IconButtonProps[];
+    active?: IconButtonProps[];
+    focus: IconButtonProps[];
+  };
 }
 
 const Template = ({
@@ -28,16 +33,15 @@ const Template = ({
   const component = componentState.map((state, index) => {
     const isDisabled = state === 'disabled';
     const isFocus = state === 'focus';
-    const datas = isDisabled ? disabled : base;
+    const iconButtonProps = isDisabled ? disabled : base;
 
-    const list = datas.map((p, i) => {
+    const list = iconButtonProps.map((p, i) => {
       return (
         <IconButton
           active={state === 'active'}
           appearance={appearance}
           disabled={isDisabled}
           key={i.toString()}
-          icon={<Plus size="small" />}
           className={isFocus ? 'focus ' + p.className : p.className}
           {...p}
         />
@@ -60,28 +64,32 @@ const Template = ({
   return <>{component}</>;
 };
 
-const buttonState = [
+const buttonState: IconButtonProps[] = [
   {
     size: 'xsmall',
+    icon: <Plus size="small" />,
   },
   {
     size: 'small',
+    icon: <Plus size="small" />,
   },
   {
     size: 'medium',
+    icon: <Plus size="small" />,
   },
   {
     size: 'large',
+    icon: <Plus size="small" />,
   },
   {
     size: 'small',
     icon: <Settings size="small" />,
-    theme: 'round',
+    rounded: true,
   },
   {
     size: 'medium',
     icon: <Settings size="small" />,
-    theme: 'round',
+    rounded: true,
   },
 ];
 

--- a/packages/IconButton/src/IconButton.tsx
+++ b/packages/IconButton/src/IconButton.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import cx from 'classnames';
 
-import Button from '@igloo-ui/button';
+import Button, { ButtonProps } from '@igloo-ui/button';
 
 import './icon-button.scss';
 
 export type Size = 'xsmall' | 'small' | 'medium' | 'large';
 
-export interface IconButtonProps
-  extends React.ComponentPropsWithoutRef<'button'> {
+export interface IconButtonProps extends Omit<ButtonProps, 'size'> {
   /** Add class names to the surrounding DOM container. */
   className?: string;
   /** Icon React node to represent the value of the button */


### PR DESCRIPTION
refactor: Change IconButtonProps interface extends
fix: Storybook `IconButton` now use rounded property instead of theme
refactor: Update minimal `@igloo-ui/button` version to 0.1.6