### PR TITLE
Fix Button having object other than string in title

### DIFF
--- a/.changeset/fresh-balloons-attack.md
+++ b/.changeset/fresh-balloons-attack.md
@@ -1,0 +1,5 @@
+---
+'@igloo-ui/button': patch
+---
+
+Fixed the case where the content of the Button is not text, but that we tried to display the object in the title property.

--- a/packages/Button/src/Button.tsx
+++ b/packages/Button/src/Button.tsx
@@ -64,6 +64,8 @@ const Button: React.FunctionComponent<ButtonProps> = (props: ButtonProps) => {
   const hasIconLeading = iconLeading !== undefined;
   const hasIconTrailing = iconTrailing !== undefined;
   const hasIcon = hasIconLeading || hasIconTrailing;
+  const childrenIsAString =
+    typeof children === 'string' || children instanceof String;
 
   const classes = cx('ids-btn', className, {
     'ids-btn--small': size === 'small',
@@ -109,7 +111,7 @@ const Button: React.FunctionComponent<ButtonProps> = (props: ButtonProps) => {
       data-test={dataTest}
       data-intercom-target={intercomTarget}
       type={type}
-      title={children?.toString()}
+      title={childrenIsAString ? children?.toString() : ''}
       onClick={onClick}
       {...rest}
     >


### PR DESCRIPTION
Fixes #45 

Before:
![image](https://user-images.githubusercontent.com/4323800/151446365-342cfee3-46ca-4cfe-a93f-539f57b4875d.png)


After:
![image](https://user-images.githubusercontent.com/4323800/151446383-ca3ddfd4-5e87-441e-b731-f9ed68885ef8.png)
