### PR TITLE
Fix(iconbutton): Remove useless background property already specified in button

### DIFF
--- a/.changeset/forty-apricots-battle.md
+++ b/.changeset/forty-apricots-battle.md
@@ -1,0 +1,5 @@
+---
+'@igloo-ui/icon-button': patch
+---
+
+Remove useless background property already specified in button

--- a/packages/IconButton/src/icon-button.scss
+++ b/packages/IconButton/src/icon-button.scss
@@ -60,7 +60,6 @@
   &.ids-btn {
     &--ghost {
       color: var(--ids-icon-btn-ghost);
-      background: var(--ids-icon-btn-background-ghost);
 
       &:hover {
         color: var(--ids-icon-btn-ghost-hover);


### PR DESCRIPTION
This property is useless since it is already defined in .ids-btn--ghost. Also, the variable does not exist.