### PR TITLE
fix: secondary button empty bg on hover state

### DIFF
--- a/.changeset/poor-donkeys-brake.md
+++ b/.changeset/poor-donkeys-brake.md
@@ -1,0 +1,5 @@
+---
+'@igloo-ui/button': patch
+---
+
+Fix secondary button empty background on hover state

--- a/packages/Button/src/button.scss
+++ b/packages/Button/src/button.scss
@@ -33,6 +33,7 @@
   --ids-btn-border-secondary-hover: #{$grey-600};
   --ids-btn-border-secondary-active: #{$electric-blue-500};
   --ids-btn-background-secondary: #{$samoyed};
+  --ids-btn-background-secondary-hover: #{$samoyed};
   --ids-btn-background-secondary-active: #{$electric-blue-50};
   --ids-btn-background-secondary-disabled: #{$grey-300};
 


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/2379339/157309802-d94f3a5a-8293-460b-82e3-0cbd3b4be1c5.png)

### After
<img width="1036" alt="Capture d’écran, le 2022-03-08 à 14 24 11" src="https://user-images.githubusercontent.com/2379339/157310198-c123cead-9f9a-4b3c-a7f8-11c4b2bcf1b4.png">

