### PR TITLE
Change @import of font.css for @use in SASS files

### DIFF
--- a/.changeset/twelve-pillows-shop.md
+++ b/.changeset/twelve-pillows-shop.md
@@ -1,0 +1,16 @@
+---
+'@igloo-ui/alert': patch
+'@igloo-ui/button': patch
+'@igloo-ui/card': patch
+'@igloo-ui/checkbox': patch
+'@igloo-ui/helper-text': patch
+'@igloo-ui/hyperlink': patch
+'@igloo-ui/icon-button': patch
+'@igloo-ui/input': patch
+'@igloo-ui/kashim': patch
+'@igloo-ui/radio': patch
+'@igloo-ui/toaster': patch
+'@igloo-ui/tooltip': patch
+---
+
+Change @import of font.css file for a @use in SASS files

--- a/packages/Alert/src/alert.scss
+++ b/packages/Alert/src/alert.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 @import './mixins';
 
 :root {

--- a/packages/Button/src/button.scss
+++ b/packages/Button/src/button.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Card/src/card.scss
+++ b/packages/Card/src/card.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Checkbox/src/checkbox.scss
+++ b/packages/Checkbox/src/checkbox.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/HelperText/src/helper-text.scss
+++ b/packages/HelperText/src/helper-text.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Hyperlink/src/hyperlink.scss
+++ b/packages/Hyperlink/src/hyperlink.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/IconButton/src/icon-button.scss
+++ b/packages/IconButton/src/icon-button.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Input/src/input.scss
+++ b/packages/Input/src/input.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Kashim/src/kashim.scss
+++ b/packages/Kashim/src/kashim.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 .ids-kashim {
   display: flex;

--- a/packages/Radio/src/radio.scss
+++ b/packages/Radio/src/radio.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Toaster/src/toaster.scss
+++ b/packages/Toaster/src/toaster.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */

--- a/packages/Tooltip/src/tooltip.scss
+++ b/packages/Tooltip/src/tooltip.scss
@@ -1,5 +1,5 @@
+@use '~@igloo-ui/tokens/dist/fonts.css';
 @import '~@igloo-ui/tokens/dist/base10/variables';
-@import '~@igloo-ui/tokens/dist/fonts.css';
 
 :root {
   /* Default */


### PR DESCRIPTION
Pour régler un problème de double import de fichier CSS une fois IconButton compilé, on va maintenant faire des `@use` pour les fichiers CSS au lieu de `@import`.

Ici, c'Est le changement de `@import '~@igloo-ui/tokens/dist/fonts.css';` pour `@use '~@igloo-ui/tokens/dist/fonts.css';` dnas chacun de nos fichiers SASS l'utilisant.