### PR TITLE
fix(Button): Temporary quick fix on ghost danger button

### DIFF
--- a/.changeset/red-badgers-sip.md
+++ b/.changeset/red-badgers-sip.md
@@ -1,0 +1,5 @@
+---
+'@igloo-ui/button': patch
+---
+
+Temporary quick fix on ghost danger button by adding `.ids-btn` prefix

--- a/packages/Button/src/button.scss
+++ b/packages/Button/src/button.scss
@@ -307,22 +307,22 @@
   background: var(--ids-btn-background-ghost);
 }
 
-.ids-btn--ghost-danger {
+.ids-btn.ids-btn--ghost-danger {
   color: var(--ids-btn-text-ghost-danger);
   background: var(--ids-btn-background-ghost);
   padding-left: 0;
   padding-right: 0;
 }
 
-.ids-btn--ghost-danger:focus,
-.ids-btn--ghost-danger.focus,
-.ids-btn--ghost-danger:hover {
+.ids-btn.ids-btn--ghost-danger:focus,
+.ids-btn.ids-btn--ghost-danger.focus,
+.ids-btn.ids-btn--ghost-danger:hover {
   color: var(--ids-btn-text-ghost-danger-hover);
   background: var(--ids-btn-background-ghost);
 }
 
-.ids-btn--ghost-danger.ids-btn--disabled,
-.ids-btn--ghost-danger:disabled {
+.ids-btn.ids-btn--ghost-danger.ids-btn--disabled,
+.ids-btn.ids-btn--ghost-danger:disabled {
   color: var(--ids-btn-text-ghost-danger-disabled);
   background: var(--ids-btn-background-ghost);
 }


### PR DESCRIPTION
Dans portal le style associé a la class `.ids-btn` override le style de `.ids-btn--ghost-danger` dans un context particulier. En attendant de trouver pour quel raison cette erreur apparait on prefix la class avec `.ids-btn`

![ghost-danger](https://user-images.githubusercontent.com/2379339/177403415-b0712ba9-765a-4844-ac94-c6e6bdc9b3bc.png)
