### PR TITLE
fix(AreaChart): Issues with loading and empty state

### DIFF
--- a/.changeset/old-numbers-own.md
+++ b/.changeset/old-numbers-own.md
@@ -1,0 +1,8 @@
+---
+"@igloo-ui/area-chart": patch
+---
+
+fix(AreaChart): Issues with loading and empty state
+- rename the css animation to avoid conflicts
+- update y-axis size when the loading state disappeared
+- change the orientation of animation for empty state

--- a/packages/AreaChart/src/AreaChart.stories.tsx
+++ b/packages/AreaChart/src/AreaChart.stories.tsx
@@ -219,6 +219,7 @@ Overview.args = {
   },
   scoreFormatter: nFormatter,
   range: { min: 'auto', max: 'auto' },
+  loading: false,
 };
 
 export const OneWeek = () => {

--- a/packages/AreaChart/src/AreaChart.tsx
+++ b/packages/AreaChart/src/AreaChart.tsx
@@ -121,6 +121,7 @@ const AreaChart: React.FunctionComponent<AreaChartProps> = (
     payload,
     skeletonWidth = DEFAULT_SKELETON_WIDTH,
     skeletonHeight = DEFAULT_SKELETON_HEIGHT,
+    orientation,
   }: {
     x?: number;
     y?: number;
@@ -128,12 +129,17 @@ const AreaChart: React.FunctionComponent<AreaChartProps> = (
     payload?: { offset: number };
     skeletonWidth?: number;
     skeletonHeight?: number;
+    orientation?: string;
   }) => {
     let positionX;
     let positionY;
 
     if (x && y && payload) {
-      positionX = x - skeletonWidth / 2 + payload.offset / 2;
+      const positionBottomCenter = x - skeletonWidth / 2 + payload.offset / 2;
+      const positionLeft = x - skeletonWidth;
+
+      positionX =
+        orientation === 'bottom' ? positionBottomCenter : positionLeft;
       positionY = y - skeletonHeight / 2 + payload.offset / 2;
     }
 
@@ -235,13 +241,8 @@ const AreaChart: React.FunctionComponent<AreaChartProps> = (
   };
 
   const { yAxisWidth, setChartRef } = useDynamicYAxisWidth({
-    yAxisWidthModifier: (x) => {
-      let width = x;
-      if (loading) {
-        width = DEFAULT_SKELETON_WIDTH;
-      }
-      return width + 20;
-    },
+    yAxisWidthModifier: (x) => x + 20,
+    loading,
   });
 
   const cartesianGridConfig = {
@@ -370,12 +371,14 @@ const AreaChart: React.FunctionComponent<AreaChartProps> = (
       });
     } else {
       const dates = getTicks();
-      updatedAreaChartData = dates.map((date) => {
-        return {
-          dateTimeStamp: date,
-          score: 0,
-        };
-      });
+      updatedAreaChartData = dates
+        .map((date) => {
+          return {
+            dateTimeStamp: date,
+            score: 0,
+          };
+        })
+        .reverse();
     }
 
     setAreaChartData(updatedAreaChartData);

--- a/packages/AreaChart/src/area-chart.scss
+++ b/packages/AreaChart/src/area-chart.scss
@@ -19,11 +19,11 @@
 }
 
 .ids-area-chart-skeleton-animation {
-  animation: pulse-light 1.5s infinite ease-in-out;
+  animation: ids-pulse-light 1.5s infinite ease-in-out;
 }
 
 /* stylelint-disable */
-@keyframes pulse-light {
+@keyframes ids-pulse-light {
   0% {
     fill: rgb(tokens.$grey-600, 0.01);
   }

--- a/packages/AreaChart/src/hooks/useDynamicYAxisWidth.tsx
+++ b/packages/AreaChart/src/hooks/useDynamicYAxisWidth.tsx
@@ -3,10 +3,12 @@ import * as React from 'react';
 // eslint-disable-next-line max-len
 const AXIS_TICK_VALUE_SELECTOR = `.recharts-cartesian-axis-tick-value[orientation="left"],
 .recharts-cartesian-axis-tick-value[orientation="right"]`;
+const AXIS_TICK_VALUE_ANIMATION_SELECTOR = `.recharts-cartesian-axis-tick-value[orientation="left"], .ids-area-chart-skeleton-animation`;
 const DEFAULT_WIDTH = 60;
 
 type Props = {
   yAxisWidthModifier?: (width: number) => number;
+  loading?: boolean;
 };
 
 type ReturnValues = {
@@ -16,14 +18,16 @@ type ReturnValues = {
 };
 
 const useDynamicYAxisWidth = (props: undefined | Props): ReturnValues => {
-  const { yAxisWidthModifier } = props || {};
+  const { yAxisWidthModifier, loading = false } = props || {};
   const [yAxisWidthState, setYAxisWidthState] = React.useState(DEFAULT_WIDTH);
 
   const setChartRef = React.useCallback(
     (chartRef) => {
       if (chartRef != null && chartRef.container != null) {
         const tickValueElements = chartRef.container.querySelectorAll(
-          AXIS_TICK_VALUE_SELECTOR
+          loading
+            ? AXIS_TICK_VALUE_ANIMATION_SELECTOR
+            : AXIS_TICK_VALUE_SELECTOR
         );
         const highestWidth = [...tickValueElements]
           .map((el) => {


### PR DESCRIPTION
- rename the css animation to avoid conflicts
- update y-axis size when the loading state disappeared
- change the orientation of animation for empty state

Issue #298, OV-41029