### PR TITLE
docs: Adding a troubleshooting section in the doc

### DIFF
--- a/.changeset/silly-windows-cover.md
+++ b/.changeset/silly-windows-cover.md
@@ -1,0 +1,6 @@
+---
+'@igloo-ui/dialog': patch
+'@igloo-ui/modal': patch
+---
+
+added troubleshooting section in the readme for workaround about Closing Dialog on top of Modal will close both

--- a/packages/Dialog/README.md
+++ b/packages/Dialog/README.md
@@ -47,3 +47,11 @@ const handleValidate = () => {
     onValidate={handleValidate}
 />
 ```
+
+## Troubleshooting
+
+**When a Dialog opens above a Modal**
+
+In this case when you close the Dialog the Modal closes automatically, here is a workaround to remedy this.
+
+To solve the problem set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.

--- a/packages/Dialog/README.md
+++ b/packages/Dialog/README.md
@@ -52,6 +52,6 @@ const handleValidate = () => {
 
 **When a Dialog opens above a Modal**
 
-In this case when you close the Dialog the Modal closes automatically, here is a workaround to remedy this.
+In this case, when you close the Dialog, the Modal closes automatically. Here is a workaround to remedy this.
 
 To solve the problem, set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.

--- a/packages/Dialog/README.md
+++ b/packages/Dialog/README.md
@@ -54,4 +54,4 @@ const handleValidate = () => {
 
 In this case when you close the Dialog the Modal closes automatically, here is a workaround to remedy this.
 
-To solve the problem set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.
+To solve the problem, set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.

--- a/packages/Modal/README.md
+++ b/packages/Modal/README.md
@@ -52,4 +52,4 @@ const [show, setShow] = useState(false);
 
 In this case, when you close the Dialog, the Modal closes automatically. Here is a workaround to remedy this.
 
-To solve the problem set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.
+To solve the problem, set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.

--- a/packages/Modal/README.md
+++ b/packages/Modal/README.md
@@ -50,6 +50,6 @@ const [show, setShow] = useState(false);
 
 **When a Dialog opens above a Modal**
 
-In this case when you close the Dialog the Modal closes automatically, here is a workaround to remedy this.
+In this case, when you close the Dialog, the Modal closes automatically. Here is a workaround to remedy this.
 
 To solve the problem set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.

--- a/packages/Modal/README.md
+++ b/packages/Modal/README.md
@@ -45,3 +45,11 @@ const [show, setShow] = useState(false);
   Modal content
 </Modal>;
 ```
+
+## Troubleshooting
+
+**When a Dialog opens above a Modal**
+
+In this case when you close the Dialog the Modal closes automatically, here is a workaround to remedy this.
+
+To solve the problem set the `isClosable` property of the Modal to `false` when the Dialog component is up and then return to `true` when it closes.


### PR DESCRIPTION
We explain how to work around the problem of the output on the modal and the dialog component

OV-42443