### PR TITLE
Center modal using flex instructions

### DIFF
--- a/.changeset/young-snakes-own.md
+++ b/.changeset/young-snakes-own.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/modal": patch
+---
+
+Center modal using flex instructions

--- a/packages/Modal/src/Modal.tsx
+++ b/packages/Modal/src/Modal.tsx
@@ -160,7 +160,7 @@ const Modal: React.FunctionComponent<ModalProps> = (props: ModalProps) => {
       </AnimatePresence>
       <AnimatePresence onExitComplete={onExitComplete}>
         {isOpen && (
-          <m.div className="ids-modal-wrapper">
+          <m.div className="ids-modal__wrapper">
             <m.div
               key={`${keyValue}_modal`}
               className={classes}

--- a/packages/Modal/src/Modal.tsx
+++ b/packages/Modal/src/Modal.tsx
@@ -121,20 +121,14 @@ const Modal: React.FunctionComponent<ModalProps> = (props: ModalProps) => {
     open: {
       opacity: 1,
       scale: 1,
-      x: '-50%',
-      y: '-50%',
     },
     close: {
       opacity: 0,
       scale: 1,
-      x: '-50%',
-      y: '-50%',
     },
     initial: {
       opacity: 0,
       scale: 0.95,
-      x: '-50%',
-      y: '-50%',
     },
   };
 
@@ -166,88 +160,90 @@ const Modal: React.FunctionComponent<ModalProps> = (props: ModalProps) => {
       </AnimatePresence>
       <AnimatePresence onExitComplete={onExitComplete}>
         {isOpen && (
-          <m.div
-            key={`${keyValue}_modal`}
-            className={classes}
-            data-test={dataTest}
-            {...(overlayProps as any)}
-            {...dialogProps}
-            initial="initial"
-            animate="open"
-            exit="close"
-            variants={modalVariants}
-            transition={{ duration: 0.2 }}
-            ref={ref}
-          >
-            <div
-              className={cx('ids-modal__header', {
-                'ids-modal__header--with-back-btn': displayBackBtn,
-              })}
+          <m.div className="ids-modal-wrapper">
+            <m.div
+              key={`${keyValue}_modal`}
+              className={classes}
+              data-test={dataTest}
+              {...(overlayProps as any)}
+              {...dialogProps}
+              initial="initial"
+              animate="open"
+              exit="close"
+              variants={modalVariants}
+              transition={{ duration: 0.2 }}
+              ref={ref}
             >
-              {displayBackBtn ? (
+              <div
+                className={cx('ids-modal__header', {
+                  'ids-modal__header--with-back-btn': displayBackBtn,
+                })}
+              >
+                {displayBackBtn ? (
+                  <IconButton
+                    size="small"
+                    className="ids-modal__back"
+                    onClick={() => {
+                      if (carousel && carousel.currentSlide) {
+                        handleOnPageChange(carousel.currentSlide - 1);
+                      }
+                    }}
+                    appearance={{ type: 'ghost', variant: 'secondary' }}
+                    icon={<ChevronLeft size="medium" />}
+                  />
+                ) : (
+                  <></>
+                )}
+
+                {title && <h5 className="ids-modal__title">{title}</h5>}
+
                 <IconButton
                   size="small"
-                  className="ids-modal__back"
-                  onClick={() => {
-                    if (carousel && carousel.currentSlide) {
-                      handleOnPageChange(carousel.currentSlide - 1);
-                    }
-                  }}
+                  className="ids-modal__close"
+                  onClick={onClose}
                   appearance={{ type: 'ghost', variant: 'secondary' }}
-                  icon={<ChevronLeft size="medium" />}
+                  aria-label={closeBtnAriaLabel}
+                  icon={<Close />}
                 />
-              ) : (
-                <></>
-              )}
+              </div>
+              <div className="ids-modal__content">
+                {children}
 
-              {title && <h5 className="ids-modal__title">{title}</h5>}
-
-              <IconButton
-                size="small"
-                className="ids-modal__close"
-                onClick={onClose}
-                appearance={{ type: 'ghost', variant: 'secondary' }}
-                aria-label={closeBtnAriaLabel}
-                icon={<Close />}
-              />
-            </div>
-            <div className="ids-modal__content">
-              {children}
-
-              {carousel && (
-                <Carousel
-                  onPageChange={carousel.onPageChange}
-                  currentSlide={carousel.currentSlide}
-                  primaryAction={primaryAction}
-                  secondaryAction={secondaryAction}
-                  className="ids-modal__carousel"
-                >
-                  {carousel.slides.map((slide, index) => {
-                    return (
-                      <div
-                        key={`slide_${index.toString()}`}
-                        className="ids-modal__carousel-slide"
-                      >
-                        {slide}
-                      </div>
-                    );
-                  })}
-                </Carousel>
-              )}
-
-              {(primaryAction || secondaryAction) && !carousel && (
-                <div className="ids-modal__footer">
-                  {secondaryAction &&
-                    React.cloneElement(secondaryAction, {
-                      className: 'ids-modal__footer-action',
+                {carousel && (
+                  <Carousel
+                    onPageChange={carousel.onPageChange}
+                    currentSlide={carousel.currentSlide}
+                    primaryAction={primaryAction}
+                    secondaryAction={secondaryAction}
+                    className="ids-modal__carousel"
+                  >
+                    {carousel.slides.map((slide, index) => {
+                      return (
+                        <div
+                          key={`slide_${index.toString()}`}
+                          className="ids-modal__carousel-slide"
+                        >
+                          {slide}
+                        </div>
+                      );
                     })}
-                  {primaryAction &&
-                    React.cloneElement(primaryAction, {
-                      className: 'ids-modal__footer-action',
-                    })}
-                </div>
-              )}
-            </div>
+                  </Carousel>
+                )}
+
+                {(primaryAction || secondaryAction) && !carousel && (
+                  <div className="ids-modal__footer">
+                    {secondaryAction &&
+                      React.cloneElement(secondaryAction, {
+                        className: 'ids-modal__footer-action',
+                      })}
+                    {primaryAction &&
+                      React.cloneElement(primaryAction, {
+                        className: 'ids-modal__footer-action',
+                      })}
+                  </div>
+                )}
+              </div>
+            </m.div>
           </m.div>
         )}
       </AnimatePresence>

--- a/packages/Modal/src/modal.scss
+++ b/packages/Modal/src/modal.scss
@@ -78,6 +78,18 @@
   z-index: var(--ids-modal-overlay-index);
 }
 
+.ids-modal-wrapper {
+  display: flex;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  justify-content: center;
+  align-items: center;
+  z-index: var(--ids-modal-index);
+}
+
 .ids-modal {
   background-color: var(--ids-modal-background);
   border-radius: var(--ids-modal-radius);
@@ -90,12 +102,7 @@
   max-height: 100%;
   max-width: var(--ids-modal-max-width);
   overflow-y: auto;
-  left: 50%;
-  position: fixed;
-  top: 50%;
-  transform: translate3d(-50%, -50%, 0);
   width: var(--ids-modal-width);
-  z-index: var(--ids-modal-index);
 
   /* Removes the focus-within outline around the modal */
   outline: none;

--- a/packages/Modal/src/modal.scss
+++ b/packages/Modal/src/modal.scss
@@ -78,7 +78,7 @@
   z-index: var(--ids-modal-overlay-index);
 }
 
-.ids-modal-wrapper {
+.ids-modal__wrapper {
   display: flex;
   position: fixed;
   top: 0;


### PR DESCRIPTION
### Contribution reason
The CSS `transform` instruction used to center the modal make a position offset when using drag&drop with `react-beautiful-dnd` inside a modal.

### Changes
- Wrapping the modal in a div with `className="ids-modal-wrapper"`
- Remove transform and fixed positioning on the modal
- Center the modal inside the wrapper by using flex instruction in the wrapper

### Tests
```diff
+ Test Suites: 41 passed, 41 total
+ Tests:       257 passed, 257 total
+ Snapshots:   59 passed, 59 total
# Time:        18.473 s
# Ran all test suites.
```