### PR TITLE
Fix: Add cleanup for onBlur

### DIFF
--- a/.changeset/twelve-balloons-think.md
+++ b/.changeset/twelve-balloons-think.md
@@ -1,0 +1,5 @@
+---
+'@igloo-ui/text-editor': patch
+---
+
+Fixed a bug where onBlur would be called multiple times (once for each render since last call).

--- a/packages/TextEditor/src/TextEditor.stories.tsx
+++ b/packages/TextEditor/src/TextEditor.stories.tsx
@@ -23,7 +23,8 @@ export default {
 
 type Story = StoryObj<typeof TextEditor>;
 
-const content = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Pre loaded content here","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Ordered list option 1","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"listitem","version":1,"value":1},{"children":[{"detail":0,"format":1,"mode":"normal","style":"","text":"Ordered list bold option 2","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"listitem","version":1,"value":2}],"direction":"ltr","format":"","indent":0,"type":"list","version":1,"listType":"number","start":1,"tag":"ol"}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
+const content =
+  '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Pre loaded content here","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Ordered list option 1","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"listitem","version":1,"value":1},{"children":[{"detail":0,"format":1,"mode":"normal","style":"","text":"Ordered list bold option 2","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"listitem","version":1,"value":2}],"direction":"ltr","format":"","indent":0,"type":"list","version":1,"listType":"number","start":1,"tag":"ol"}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
 
 export const Overview: Story = {
   args: {
@@ -36,8 +37,16 @@ export const Overview: Story = {
 
 export const isEmpty: Story = {
   args: {
-    onContentIsEmpty: (isEmpty) => {
+    onContentIsEmpty: (isEmpty: boolean) => {
       console.log('content is empty:', isEmpty);
+    },
+  },
+};
+
+export const OnBlur: Story = {
+  args: {
+    onBlur: () => {
+      console.log('blurred!');
     },
   },
 };

--- a/packages/TextEditor/src/plugins/OnFocusPlugin.tsx
+++ b/packages/TextEditor/src/plugins/OnFocusPlugin.tsx
@@ -20,7 +20,7 @@ export function OnFocusPlugin({
 
   useLayoutEffect(() => {
     if (onFocus) {
-      editor.registerCommand(
+      return editor.registerCommand(
         FOCUS_COMMAND,
         () => {
           onFocus(editor);
@@ -33,7 +33,7 @@ export function OnFocusPlugin({
 
   useLayoutEffect(() => {
     if (onBlur) {
-      editor.registerCommand(
+      return editor.registerCommand(
         BLUR_COMMAND,
         () => {
           onBlur(editor);


### PR DESCRIPTION
The effect adding the onBlur to the text editor was missing the cleanup. This means that onBlur would be called multiple times, sometime with stale data because of closures.

Also added a story to test this. (the pre commit hook also decide to autofix some styling)