### PR TITLE
Add possibility to open link in a new tab

### DIFF
--- a/.changeset/heavy-queens-kneel.md
+++ b/.changeset/heavy-queens-kneel.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/text-editor": minor
+---
+
+Add possibility to open link in a new tab

--- a/packages/TextEditor/src/TextEditor.tsx
+++ b/packages/TextEditor/src/TextEditor.tsx
@@ -60,6 +60,7 @@ export interface Messages {
   private?: MessageOptions;
   linkEditorEdit?: MessageOptions;
   linkEditorRemove?: MessageOptions;
+  linkEditorTargetBlank?: MessageOptions;
   linkEditorCancel?: MessageOptions;
   linkEditorSave?: MessageOptions;
 }
@@ -130,6 +131,7 @@ const TextEditor: React.FunctionComponent<TextEditorProps> = ({
     private: { text: 'Visible to you only' },
     linkEditorEdit: { tooltip: 'Edit link' },
     linkEditorCancel: { tooltip: 'Cancel' },
+    linkEditorTargetBlank: { tooltip: 'Open in a new tab' },
     linkEditorRemove: { tooltip: 'Remove link' },
     linkEditorSave: { tooltip: 'Save' },
   },

--- a/packages/TextEditor/src/TextEditor.tsx
+++ b/packages/TextEditor/src/TextEditor.tsx
@@ -107,6 +107,8 @@ export interface TextEditorProps
   /** Whether or not the editor should display
    * the toolbar when editor is focused */
   showToolbarOnFocus?: boolean;
+  /** Wether the user can choose the opening mode of a link */
+  canSelectLinkOpeningMode?: boolean;
 }
 
 const TextEditor: React.FunctionComponent<TextEditorProps> = ({
@@ -144,6 +146,7 @@ const TextEditor: React.FunctionComponent<TextEditorProps> = ({
   readOnly = false,
   showToolbar = true,
   showToolbarOnFocus = false,
+  canSelectLinkOpeningMode = false,
 }: TextEditorProps) => {
   const [hasFocus, setHasFocus] = React.useState(autoFocus);
 
@@ -245,6 +248,7 @@ const TextEditor: React.FunctionComponent<TextEditorProps> = ({
                 <FloatingLinkEditorPlugin
                   anchorElem={floatingAnchorElem}
                   messages={messages}
+                  canSelectLinkOpeningMode={canSelectLinkOpeningMode}
                 />
               )}
               {isClearable && <ClearEditorPlugin />}

--- a/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
+++ b/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
@@ -59,12 +59,14 @@ function FloatingLinkEditor({
   setIsLink,
   anchorElem,
   messages,
+  canSelectLinkOpeningMode
 }: {
   editor: LexicalEditor;
   isLink: boolean;
   setIsLink: Dispatch<boolean>;
   anchorElem: HTMLElement;
   messages?: Messages;
+  canSelectLinkOpeningMode?: boolean;
 }): JSX.Element | null {
   const inputRef = useRef<HTMLInputElement>(null);
   const [linkUrl, setLinkUrl] = useState('');
@@ -254,17 +256,19 @@ function FloatingLinkEditor({
           monitorInputInteraction(event);
         }}
       />
-      <IconButton
-        size="small"
-        icon={<External size="medium" />}
-        className="ids-link-editor__external"
-        appearance={isTargetBlank ? 'primary' : 'ghost'}
-        onClick={() => {
-          setIsTargetBlank((prevValue) => !prevValue);
-        }}
-        // @ts-ignore
-        title={messages?.linkEditorTargetBlank?.tooltip}
-      />
+      {canSelectLinkOpeningMode && (
+        <IconButton
+          size="small"
+          icon={<External size="medium" />}
+          className="ids-link-editor__external"
+          appearance={isTargetBlank ? 'primary' : 'ghost'}
+          onClick={() => {
+            setIsTargetBlank((prevValue) => !prevValue);
+          }}
+          // @ts-ignore
+          title={messages?.linkEditorTargetBlank?.tooltip}
+        />
+      )}
       <IconButton
         size="small"
         icon={<Close size="medium" />}
@@ -355,6 +359,7 @@ function useFloatingLinkEditorToolbar(
   editor: LexicalEditor,
   anchorElem: HTMLElement,
   messages?: Messages,
+  canSelectLinkOpeningMode?: boolean
 ): JSX.Element | null {
   const [activeEditor, setActiveEditor] = useState(editor);
   const [isLink, setIsLink] = useState(false);
@@ -401,6 +406,7 @@ function useFloatingLinkEditorToolbar(
       anchorElem={anchorElem}
       setIsLink={setIsLink}
       messages={messages}
+      canSelectLinkOpeningMode={canSelectLinkOpeningMode}
     />
   );
 }
@@ -408,10 +414,12 @@ function useFloatingLinkEditorToolbar(
 export function FloatingLinkEditorPlugin({
   anchorElem = document.body,
   messages,
+  canSelectLinkOpeningMode
 }: {
   anchorElem?: HTMLElement;
   messages?: Messages;
+  canSelectLinkOpeningMode?: boolean;
 }): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
-  return useFloatingLinkEditorToolbar(editor, anchorElem, messages);
+  return useFloatingLinkEditorToolbar(editor, anchorElem, messages, canSelectLinkOpeningMode);
 }

--- a/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
+++ b/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
@@ -45,6 +45,7 @@ import Checkmark from '@igloo-ui/icons/dist/Checkmark';
 import Delete from '@igloo-ui/icons/dist/Delete';
 import Close from '@igloo-ui/icons/dist/Close';
 import Edit from '@igloo-ui/icons/dist/Edit';
+import External from '@igloo-ui/icons/dist/Launch';
 
 import type { Messages } from 'src/TextEditor';
 import { getSelectedNode } from '../utils/getSelectedNode';
@@ -69,6 +70,7 @@ function FloatingLinkEditor({
   const [linkUrl, setLinkUrl] = useState('');
   const [editedLinkUrl, setEditedLinkUrl] = useState('');
   const [isEditMode, setEditMode] = useState(false);
+  const [isTargetBlank, setIsTargetBlank] = useState(true);
   const [show, setShow] = useState(false);
   const [lastSelection, setLastSelection] = useState<
     RangeSelection | GridSelection | NodeSelection | null
@@ -217,7 +219,11 @@ function FloatingLinkEditor({
   const handleLinkSubmission = (): void => {
     if (lastSelection !== null) {
       if (linkUrl !== '') {
-        editor.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl(editedLinkUrl));
+        const targetValue = isTargetBlank ? '_blank' : '_self';
+        editor.dispatchCommand(TOGGLE_LINK_COMMAND, {
+          url: sanitizeUrl(editedLinkUrl),
+          target: targetValue
+        });
       }
       setEditMode(false);
     }
@@ -247,6 +253,17 @@ function FloatingLinkEditor({
         onKeyDown={(event) => {
           monitorInputInteraction(event);
         }}
+      />
+      <IconButton
+        size="small"
+        icon={<External size="medium" />}
+        className="ids-link-editor__external"
+        appearance={isTargetBlank ? 'primary' : 'ghost'}
+        onClick={() => {
+          setIsTargetBlank((prevValue) => !prevValue);
+        }}
+        // @ts-ignore
+        title={messages?.linkEditorTargetBlank?.tooltip}
       />
       <IconButton
         size="small"


### PR DESCRIPTION
### Contribution reason
We would like to open link in a new tab but the target attribute was never set.

### Changes
- Adding a toggle IconButton to set `true`/`false` the `target='[_blank|_self]'` attribute of the link from the link editor

### Screenshot
| Internal link | External link |
| --- | --- |
| ![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/82e856bb-4a07-4f2d-9a88-76b91bbc6e23) | ![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/8cb4b677-0558-434b-a468-62b9d2361742) |

![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/7fd6a3ee-6005-49f7-8238-449c128a3b51)


### States editor value during test
```json
{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Internal link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":"_self","title":null,"url":"https://www.google.com/"},{"detail":0,"format":0,"mode":"normal","style":"","text":" / ","type":"text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"External link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":"_blank","title":null,"url":"https://www.google.com/"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}
```

### Tests
```diff
+ Test Suites: 44 passed, 44 total
+ Tests:       288 passed, 288 total
+ Snapshots:   62 passed, 62 total
# Time:        27.588 s
# Ran all test suites.
```