### PR TITLE
#530 Fix url too long in link editor plugin

### DIFF
--- a/.changeset/giant-points-itch.md
+++ b/.changeset/giant-points-itch.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/text-editor": minor
+---
+
+Fix overflow url link editor

--- a/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
+++ b/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
@@ -297,6 +297,7 @@ function FloatingLinkEditor({
         target="_blank"
         rel="noopener noreferrer"
         className="ids-link-editor__link"
+        title={linkUrl}
       >
         {linkUrl}
       </a>

--- a/packages/TextEditor/src/plugins/floating-link-editor.scss
+++ b/packages/TextEditor/src/plugins/floating-link-editor.scss
@@ -51,6 +51,7 @@
     align-items: center;
     display: flex;
     flex: 1 1 auto;
+    overflow: hidden;
 }
 
 .ids-link-editor__view > * {
@@ -58,11 +59,15 @@
 }
 
 .ids-link-editor__link {
+    flex-shrink: 1;
     color: var(--ids-text-editor-link-color);
     cursor: pointer;
     font-weight: var(--ids-text-editor-link-font-weight);
     margin-right: auto;
     text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   
     &:focus,
     &:hover {


### PR DESCRIPTION
### Contribution reason
We would like to fix the overflow url when editing a link.

### Changes
- Manage the overflow and add a tooltip

### Screenshot
![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/1db9ac90-7e38-4a49-9c14-2e929b11f3ab)

### Tests
```diff
+ Test Suites: 45 passed, 45 total
+ Tests:       293 passed, 293 total
+ Snapshots:   63 passed, 63 total
# Time:        23.979 s
# Ran all test suites.
```