### PR TITLE
Fix: the toolbar to remain in focus in safari

### DIFF
--- a/.changeset/moody-moose-serve.md
+++ b/.changeset/moody-moose-serve.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/text-editor": patch
+---
+
+Fix issue with the toolbar that wouldn't display in safari

--- a/packages/TextEditor/src/plugins/ToolbarPlugin.tsx
+++ b/packages/TextEditor/src/plugins/ToolbarPlugin.tsx
@@ -186,7 +186,7 @@ export const ToolbarPlugin: React.FunctionComponent<ToolbarProps> = ({
   });
 
   return (
-    <div className={classes}>
+    <div className={classes} tabIndex={ showOnFocus ? 0 : undefined}>
       <IconButton
         size="small"
         icon={<Bold size="medium" />}


### PR DESCRIPTION
Adding a tabindex when the `showOnFocus` option is active solves the problem.

Story: IGL-81 
Issue: GH-529