### PR TITLE
Restores alignment between icon and text in a compact select

### DIFF
--- a/.changeset/fresh-poems-tickle.md
+++ b/.changeset/fresh-poems-tickle.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/select": patch
+---
+
+restores alignment between icon and text in a compact select.

--- a/packages/Select/src/select-value.scss
+++ b/packages/Select/src/select-value.scss
@@ -41,6 +41,7 @@
     padding: var(--ids-select-value-padding);
     white-space: nowrap;
     overflow: hidden;
+    align-items: center;
 
     &--compact {
         padding: var(--ids-select-value-padding-compact);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,18 +2360,6 @@
     classnames "^2.3.1"
     html-react-parser "^1.2.7"
 
-"@igloo-ui/tag@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@igloo-ui/tag/-/tag-1.2.0.tgz#ead4f7bf829e822b7bb804bb031ac51e57fba283"
-  integrity sha512-CoWpsayNyeZ0+vehFwO40YFtRLUAzHfsDtVF0Sf9jIfgzP9xNdUS3vDIv1QLxUWbxYpaptRdqje+DvPML44PDQ==
-  dependencies:
-    "@hopper-ui/tokens" "^0.3.0"
-    "@igloo-ui/ellipsis" "^0.2.0"
-    "@igloo-ui/icon-button" "^1.1.3"
-    "@igloo-ui/icons" "^1.11.0"
-    "@igloo-ui/tokens" "^2.0.0"
-    classnames "^2.3.2"
-
 "@igloo-ui/tokens@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@igloo-ui/tokens/-/tokens-2.0.0.tgz#a7977f0f7875659de8751f9413e4fc72ad2bdcd4"


### PR DESCRIPTION
### Before
<img width="274" alt="Capture d’écran, le 2023-10-06 à 14 32 57" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/a0af8be9-762a-47c0-85a2-db8cbb7ea004">

### After

<img width="273" alt="Capture d’écran, le 2023-10-06 à 14 32 19" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/5e2ceeb8-a440-41c2-98ad-a202a0fe13e7">
