### PR TITLE
Hover display for a selected radio

### DIFF
--- a/.changeset/silver-ghosts-bake.md
+++ b/.changeset/silver-ghosts-bake.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/radio": patch
+---
+
+fix the problem of displaying the hover of a selected radio

--- a/packages/Radio/src/radio.scss
+++ b/packages/Radio/src/radio.scss
@@ -116,6 +116,7 @@
     &:focus {
         outline: none;
         box-shadow: var(--focus);
+        background-color: var(--ids-radio-background-hover, var(--ids-radio-background));
     }
 
     &:hover {
@@ -123,7 +124,8 @@
         background-color: var(--ids-radio-background-hover, var(--ids-radio-background));
     }
 
-    &:checked:hover {
+    &:checked:hover,
+    &:checked:focus {
         border-color: var(--ids-radio-border-checked-hover, var(--ids-radio-border-hover));
         background-color: var(--ids-radio-background-checked, var(--ids-radio-background-checked));
 

--- a/packages/Radio/src/radio.scss
+++ b/packages/Radio/src/radio.scss
@@ -51,11 +51,9 @@
     --ids-radio-border-checked: var(--hop-neutral-border-active);
     --ids-radio-border-checked-hover: var(--hop-neutral-border-active);
     --ids-radio-background: var(--hop-neutral-surface);
-    --ids-radio-background-hover: var(--hop-neutral-surface-hover);
     --ids-radio-background-disabled: var(--hop-neutral-surface-disabled);
     --ids-radio-background-disabled-checked: var(--hop-neutral-surface-disabled);
     --ids-radio-background-checked: var(--hop-neutral-surface-active);
-    --ids-radio-check-background-checked-hover: var(--hop-neutral-icon-hover)
 }
 
 %radio {
@@ -121,14 +119,13 @@
 
     &:hover {
         border-color: var(--ids-radio-border-hover);
-        background-color: var(--ids-radio-background-hover, var(--ids-radio-background))
     }
 
     &:checked:hover {
         border-color: var(--ids-radio-border-checked-hover, var(--ids-radio-border-hover)) ;
 
         &::after {
-            background: var(--ids-radio-check-background-checked-hover, var(--ids-radio-background));
+            background: var(--ids-radio-background);
         }
     }
 

--- a/packages/Radio/src/radio.scss
+++ b/packages/Radio/src/radio.scss
@@ -51,6 +51,7 @@
     --ids-radio-border-checked: var(--hop-neutral-border-active);
     --ids-radio-border-checked-hover: var(--hop-neutral-border-active);
     --ids-radio-background: var(--hop-neutral-surface);
+    --ids-radio-background-hover: var(--hop-neutral-surface-hover);
     --ids-radio-background-disabled: var(--hop-neutral-surface-disabled);
     --ids-radio-background-disabled-checked: var(--hop-neutral-surface-disabled);
     --ids-radio-background-checked: var(--hop-neutral-surface-active);
@@ -119,10 +120,12 @@
 
     &:hover {
         border-color: var(--ids-radio-border-hover);
+        background-color: var(--ids-radio-background-hover, var(--ids-radio-background));
     }
 
     &:checked:hover {
-        border-color: var(--ids-radio-border-checked-hover, var(--ids-radio-border-hover)) ;
+        border-color: var(--ids-radio-border-checked-hover, var(--ids-radio-border-hover));
+        background-color: var(--ids-radio-background-checked, var(--ids-radio-background-checked));
 
         &::after {
             background: var(--ids-radio-background);


### PR DESCRIPTION
The hover is not displayed correctly in Igloo 

### Before

**OV**
Selected:
<img width="338" alt="Capture d’écran, le 2023-12-04 à 09 05 40" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/27e314de-a8b1-4790-aab0-1f4744d9fba8">
Selected hover:
<img width="342" alt="Capture d’écran, le 2023-12-04 à 09 05 57" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/a69d26e1-2947-4ed3-8461-4f65f6460158">


**Rebrand**
Selected:
<img width="359" alt="Capture d’écran, le 2023-12-04 à 09 07 50" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/142ac3b7-7ee9-43f0-b5fe-c9c78375b373">
Selected hover:
<img width="331" alt="Capture d’écran, le 2023-12-04 à 09 08 00" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/228f1ebd-5dbc-41fa-8514-31af499e15f1">

---

### After
Selected hover:
<img width="338" alt="Capture d’écran, le 2023-12-04 à 09 05 40" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/27e314de-a8b1-4790-aab0-1f4744d9fba8">
<img width="359" alt="Capture d’écran, le 2023-12-04 à 09 07 50" src="https://github.com/gsoft-inc/ov-igloo-ui/assets/2379339/142ac3b7-7ee9-43f0-b5fe-c9c78375b373">


IGL-99