### PR TITLE
Fix: [IGL-105] Made dismissOnEscape optional &...

### DIFF
--- a/.changeset/cuddly-boats-switch.md
+++ b/.changeset/cuddly-boats-switch.md
@@ -1,0 +1,6 @@
+---
+"@igloo-ui/dialog": patch
+"@igloo-ui/modal": patch
+---
+
+dismissOnEscape is now optional. 'contain' was removed from FocusScope inside Modal. This was causing errors in OV when dialog displayed above modal.

--- a/packages/Dialog/src/Dialog.tsx
+++ b/packages/Dialog/src/Dialog.tsx
@@ -12,7 +12,7 @@ export interface DialogProps extends React.ComponentProps<"div"> {
     /** Add a data-test tag for automated tests */
     dataTest?: string;
     /** Whether to close the dialog when the escape key is pressed */
-    dismissOnEscape: boolean;
+    dismissOnEscape?: boolean;
     /** The text for the dismiss button */
     dismissText?: string;
     /** Whether the dialog is open or not */

--- a/packages/Modal/src/Modal.tsx
+++ b/packages/Modal/src/Modal.tsx
@@ -72,7 +72,7 @@ export interface ModalProps extends OverlayProps, AriaDialogProps {
     /** Whether to close the modal when the escape key is pressed
    * @default true
    */
-    dismissOnEscape: boolean;
+    dismissOnEscape?: boolean;
 }
 
 const Modal: React.FunctionComponent<ModalProps> = (props: ModalProps) => {
@@ -168,7 +168,7 @@ const Modal: React.FunctionComponent<ModalProps> = (props: ModalProps) => {
             </AnimatePresence>
             <AnimatePresence onExitComplete={onExitComplete}>
                 {isOpen && (
-                    <FocusScope restoreFocus autoFocus contain>
+                    <FocusScope restoreFocus autoFocus>
                         <m.div className="ids-modal__wrapper">
                             <m.div
                                 key={`${keyValue}_modal`}


### PR DESCRIPTION
removed contain From FocusScope inside Modal.
It was causing issues only seen in OV, when a dialog is opened from within a modal.
Goodvibes comments section.