### PR TITLE
fix placeholder color in textarea and input

### DIFF
--- a/.changeset/twelve-ads-pump.md
+++ b/.changeset/twelve-ads-pump.md
@@ -1,0 +1,6 @@
+---
+"@igloo-ui/input": patch
+"@igloo-ui/textarea": patch
+---
+
+Bug fix to adress the Input's placeholder color not being right

--- a/packages/Input/src/input.scss
+++ b/packages/Input/src/input.scss
@@ -257,10 +257,6 @@
         display: none;
     }
 
-    .ids-input::placeholder {
-        color: var(--ids-input-color-placeholder);
-    }
-
     .ids-input::-webkit-inner-spin-button,
     .input::-webkit-outer-spin-button {
         margin: 0;
@@ -306,4 +302,9 @@
         border-color: var(--ids-input-border-color-disabled);
         box-shadow: none;
     }
+}
+
+// A bug in Chromium-based browsers causes the user agent placeholder color take precedence over the custom placeholder color when in a layer declaration.
+.ids-input::placeholder {
+    color: var(--ids-input-color-placeholder);
 }

--- a/packages/Textarea/src/textarea.scss
+++ b/packages/Textarea/src/textarea.scss
@@ -112,10 +112,6 @@
                 scroll-padding-bottom: var(--ids-textarea-char-indicator-padding-bottom);
             }
 
-            &::placeholder {
-                color: var(--ids-textarea-color-placeholder);
-            }
-
             &:focus,
             .ids-textarea--focus & {
                 border-color: var(--ids-textarea-focus-border-color);
@@ -159,4 +155,8 @@
             right: var(--ids-textarea-char-indicator-right);
         }
     }
+}
+
+.ids-textarea__field::placeholder {
+    color: var(--ids-textarea-color-placeholder);;
 }


### PR DESCRIPTION
Fix for issue https://github.com/gsoft-inc/ov-igloo-ui/issues/662

- Placeholder declarations have been moved outside layers as it's not working with Chromium based browsers.