### PR TITLE
fixed wrong variable reference in textarea

### DIFF
--- a/.changeset/hot-fishes-divide.md
+++ b/.changeset/hot-fishes-divide.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/textarea": patch
+---
+
+Font family adjustment for Textarea

--- a/packages/Textarea/src/textarea.scss
+++ b/packages/Textarea/src/textarea.scss
@@ -46,7 +46,7 @@
 
     [data-brand="workleap"] {
         /* Default */
-        --ids-textarea-font-family: var(--hop-body-sm-regular-font-family);
+        --ids-textarea-font-family: var(--hop-body-sm-font-family);
         --ids-textarea-font-size: var(--hop-body-sm-font-size);
         --ids-textarea-line-height: var(--hop-body-sm-line-height);
         --ids-textarea-color: var(--hop-neutral-text);


### PR DESCRIPTION
- Textarea font family was not applied due to a wrongly typed variable name, this has been fixed.