### PR TITLE
#683 Fix center the checkmark of the Checkbox component

### DIFF
--- a/.changeset/famous-lemons-rule.md
+++ b/.changeset/famous-lemons-rule.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/checkbox": minor
+---
+
+Center checkmark inside the checkbox

--- a/packages/Checkbox/src/checkbox.scss
+++ b/packages/Checkbox/src/checkbox.scss
@@ -215,7 +215,7 @@
             display: block;
             left: 0;
             top: 50%;
-            translate: 50% 0;
+            translate: calc(var(--ids-checkbox-check-width) / 2) 0;
             animation: check-animation ease-out 0.25s 0.15s both;
         }
 


### PR DESCRIPTION
Because the `translate: 50%` is applied on the unrotated rectangle, we need to take in consideration the rotation of almost `45deg` that involve to a higher absolute width value.

```diff
- translate: 50% 0;
+ translate: calc(var(--ids-checkbox-check-width) / 2) 0;
```

| Before | After |
| - | - |
| ![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/8d2d888b-3cb8-4eb2-aade-9942f750d6fa) <br><hr><br> ![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/089db779-21fa-4525-abf2-97f81192e6f1) | ![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/3b4fe54f-cd79-4123-86f8-0fe05f4a14f0) <br><hr><br> ![image](https://github.com/gsoft-inc/ov-igloo-ui/assets/9695045/93602ad2-3f86-4fb9-a12d-215cac4f202c) |


