### PR TITLE
fix for small radio label text not being the right size

### DIFF
--- a/.changeset/silly-bees-fix.md
+++ b/.changeset/silly-bees-fix.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/radio": patch
+---
+
+Small Radio font-size was not being applied

--- a/packages/Radio/src/radio.scss
+++ b/packages/Radio/src/radio.scss
@@ -37,7 +37,7 @@
         --ids-radio-font-family: var(--hop-body-md-font-family);
         --ids-radio-font-weight: var(--hop-body-md-font-weight);
         --ids-radio-font-size: var(--hop-body-md-font-size);
-        --ids-radio-font-size-small: var(--hop-sm-font-size);
+        --ids-radio-font-size-small: var(--hop-body-sm-font-size);
         --ids-radio-font-size-description: var(--hop-body-sm-font-size);
         --ids-radio-line-height: var(--hop-body-md-line-height);
         --ids-radio-line-height-small: var(--hop-body-sm-line-height);


### PR DESCRIPTION
Small radio label did not used the right variable resulting in a wrong font size, this has been fixed.