### PR TITLE
fix for border radius in the StackedBar component

### DIFF
--- a/.changeset/khaki-penguins-design.md
+++ b/.changeset/khaki-penguins-design.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/stacked-bar": patch
+---
+
+Addressed a bug in the StackedBar component where the radius wasn't applied with items of value 0.

--- a/packages/StackedBar/src/StackedBar.stories.tsx
+++ b/packages/StackedBar/src/StackedBar.stories.tsx
@@ -207,6 +207,47 @@ export const CustomRangeAndFormat = {
   },
 };
 
+export const ZeroFirstAndLast = {
+    args: {
+      showValue: true,
+      valueRange: { min: 0, max: 'dataMax' },
+      formatValue: (value: number) => {
+        return `${value} units`;
+      },
+      dataSet: [
+        {
+          key: 'stronglyUnfavorable',
+          label: 'Strongly Unfavorable',
+          value: 0,
+          strength: -2,
+        },
+        {
+          key: 'unfavorable',
+          label: 'Unfavorable',
+          value: 135,
+          strength: -2,
+        },
+        {
+          key: 'skipped',
+          label: 'Skipped',
+          value: 120,
+        },
+        {
+          key: 'favorable',
+          label: 'Favorable',
+          value: 245,
+          strength: 2,
+        },
+        {
+          key: 'stronglyFavorable',
+          label: 'Strongly Favorable',
+          value: 0,
+          strength: 2,
+        },
+      ],
+    },
+  };
+
 export const CustomClassAndPopoverTitle = {
   args: {
     showValue: true,

--- a/packages/StackedBar/src/StackedBar.stories.tsx
+++ b/packages/StackedBar/src/StackedBar.stories.tsx
@@ -246,7 +246,67 @@ export const ZeroFirstAndLast = {
         },
       ],
     },
-  };
+};
+
+export const OnlyZeroButLast = {
+    args: {
+      showValue: true,
+      valueRange: { min: 0, max: 'dataMax' },
+      formatValue: (value: number) => {
+        return `${value} units`;
+      },
+      dataSet: [
+        {
+          key: 'stronglyUnfavorable',
+          label: 'Strongly Unfavorable',
+          value: 0,
+          strength: -2,
+        },
+        {
+          key: 'unfavorable',
+          label: 'Unfavorable',
+          value: 0,
+          strength: -2,
+        },
+        {
+          key: 'favorable',
+          label: 'Favorable',
+          value: 245,
+          strength: 2,
+        }
+      ],
+    },
+};
+
+export const OnlyZeroButFirst = {
+    args: {
+      showValue: true,
+      valueRange: { min: 0, max: 'dataMax' },
+      formatValue: (value: number) => {
+        return `${value} units`;
+      },
+      dataSet: [
+        {
+          key: 'stronglyUnfavorable',
+          label: 'Strongly Unfavorable',
+          value: 245,
+          strength: -2,
+        },
+        {
+          key: 'unfavorable',
+          label: 'Unfavorable',
+          value: 0,
+          strength: -2,
+        },
+        {
+          key: 'favorable',
+          label: 'Favorable',
+          value: 0,
+          strength: 2,
+        }
+      ],
+    },
+};
 
 export const CustomClassAndPopoverTitle = {
   args: {

--- a/packages/StackedBar/src/StackedBar.tsx
+++ b/packages/StackedBar/src/StackedBar.tsx
@@ -197,15 +197,18 @@ const StackedBar: React.FunctionComponent<StackedBarProps> = ({
 
     if (dataSet && dataSet.length) {
         bars = dataSet.map((barInfo, key) => {
+            let isFirstNonZero = true;
+
             if (barInfo.value) {
                 const dataKey = barInfo.key;
                 let pos;
 
-                if (key === 0) {
+                if (isFirstNonZero) {
                     pos = "first" as Pos;
+                    isFirstNonZero = false;
                 }
 
-                if (key === dataSet.length - 1) {
+                if (key === dataSet.length - 1 || dataSet.slice(key + 1).every(item => !item.value)) {
                     pos = "last" as Pos;
                 }
 


### PR DESCRIPTION
Fix for issue #716.

The way the code was working is that it was checking for the first item in the dataSet even if it's value was 0, items with a 0 value are not rendered, resulting in situations where we had items with no border radius even though they were the first item rendered. The same applies to the lastItem.