### PR TITLE
Transitionned to gap in button

### DIFF
--- a/.changeset/silver-apes-impress.md
+++ b/.changeset/silver-apes-impress.md
@@ -1,0 +1,10 @@
+---
+"@igloo-ui/button": patch
+"@igloo-ui/alert": patch
+"@igloo-ui/datepicker": patch
+"@igloo-ui/dialog": patch
+"@igloo-ui/icon-button": patch
+"@igloo-ui/text-editor": patch
+---
+
+- Spacing in Button with Icon is now always shown even with non Hopper icons.

--- a/packages/Button/src/button.scss
+++ b/packages/Button/src/button.scss
@@ -572,12 +572,8 @@
         color: var(--ids-btn-icon-color);
       }
 
-      .has-icon--leading .ids-icon {
-        margin-right: var(--ids-btn-icon-margin);
-      }
-
-      .has-icon--trailing .ids-icon {
-        margin-left: var(--ids-btn-icon-margin);
+      .has-icon {
+        gap: var(--ids-btn-icon-margin);
       }
 
       .ids-btn--mobile {
@@ -605,12 +601,8 @@
           padding: var(--ids-btn-padding);
         }
 
-        .ids-btn--mobile.has-icon--leading .ids-icon {
-          margin-right: var(--ids-btn-icon-margin);
-        }
-
-        .ids-btn--mobile.has-icon--trailing .ids-icon {
-          margin-left: var(--ids-btn-icon-margin);
+        .ids-btn--mobile.has-icon {
+          gap: var(--ids-btn-icon-margin);
         }
 
         .ids-btn__label {


### PR DESCRIPTION
Fix issue #767.

- Gap is now used in button, this will ensure that any icon wether coming from Hopper or elsewhere will have the right spacing.