### PR TITLE
Hotfix/textarea fontsize

### DIFF
--- a/.changeset/lazy-tigers-yawn.md
+++ b/.changeset/lazy-tigers-yawn.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/textarea": patch
+---
+
+Fixed the font-size - it now match text-input font size

--- a/packages/Textarea/src/textarea.scss
+++ b/packages/Textarea/src/textarea.scss
@@ -46,9 +46,9 @@
 
     [data-brand="workleap"] {
         /* Default */
-        --ids-textarea-font-family: var(--hop-body-sm-font-family);
-        --ids-textarea-font-size: var(--hop-body-sm-font-size);
-        --ids-textarea-line-height: var(--hop-body-sm-line-height);
+        --ids-textarea-font-family: var(--hop-body-md-font-family);
+        --ids-textarea-font-size: var(--hop-body-md-font-size);
+        --ids-textarea-line-height: var(--hop-body-md-line-height);
         --ids-textarea-color: var(--hop-neutral-text);
         --ids-textarea-border-color: var(--hop-neutral-border);
         --ids-textarea-border-size: .0625rem;


### PR DESCRIPTION
Textarea font-size was not fitting the input font-size. This PR aims at unify these two components font size.