### PR TITLE
Fix Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
               with:
                   commit: "ci(changesets): version packages"
                   title: "Changeset: New Version"
-                  publish: yarn build && yarn publish-ci
+                  publish: yarn publish-ci
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.npm_token }}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev": "yarn build:shared && yarn build:components && yarn storybook",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "prepublish-ci": "yarn build",
+    "prepublish-ci": "yarn build:shared && yarn build:components",
     "publish-ci": "npx lerna publish from-package -y",
     "chromatic": "npx chromatic --project-token=CHROMATIC_PROJECT_TOKEN --only-changed",
     "bootstrap": "node utils/bootstrap/component.mjs && npx lerna bootstrap && yarn fix:all"


### PR DESCRIPTION
- Didn't notice there was a `prepublish-ci` that was already building, so i removed the yarn build from the command.
- Replaced the yarn build command with yarn build:shared && yarn build:components so we don't build the docs