### PR TITLE
Fixed an issue where the wrong month label was shown in rare cases

### DIFF
--- a/.changeset/loud-cameras-invent.md
+++ b/.changeset/loud-cameras-invent.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/area-chart": patch
+---
+
+Fixed an issue where the wrong month label was shown in rare cases

--- a/packages/AreaChart/src/AreaChart.tsx
+++ b/packages/AreaChart/src/AreaChart.tsx
@@ -1,31 +1,31 @@
-import * as React from "react";
+import { useLocale } from "@igloo-ui/provider";
 import cx from "classnames";
 import { DateTime, Settings } from "luxon";
+import * as React from "react";
 import {
-    AreaChart as RechartsAreaChart,
     Area,
+    CartesianGrid,
+    AreaChart as RechartsAreaChart,
+    ReferenceArea,
+    ResponsiveContainer,
+    Tooltip,
     XAxis,
     YAxis,
-    Tooltip,
-    ResponsiveContainer,
-    CartesianGrid,
-    type XAxisProps,
-    type YAxisProps,
     type DotProps,
-    ReferenceArea,
-    type LabelProps
+    type LabelProps,
+    type XAxisProps,
+    type YAxisProps
 } from "recharts";
 import type { CurveType } from "recharts/types/shape/Curve";
 import type { CartesianViewBox } from "recharts/types/util/types";
-import { useLocale } from "@igloo-ui/provider";
 
 import ChartTooltip from "./ChartTooltip";
-import useDynamicYAxisWidth from "./hooks/useDynamicYAxisWidth";
 import {
-    getNullSequenceRanges,
     getFakeScore,
+    getNullSequenceRanges,
     getUniqueKeys
 } from "./helper/unavailableData";
+import useDynamicYAxisWidth from "./hooks/useDynamicYAxisWidth";
 
 import "./area-chart.scss";
 
@@ -219,7 +219,7 @@ const AreaChart: React.FunctionComponent<AreaChartProps> = ({
                 monthString = "Sept.";
                 break;
             default:
-                monthString = date.toFormat("MMM.");
+                monthString = utcDate.toFormat("MMM.");
         }
 
         return `${monthString} ${utcDate.day}`;


### PR DESCRIPTION
We've seen an issue where a client had a range from Nov 1 to Nov 30, but the graph showed "Dec. 30" instead. The endRange property seems to work fine, so it's most likely a display issue. Looking at the formatSpecialMonth method, there was a usage of the wrong variable, which i think was the issue. 

This is a tentative fix that we will ship to the client to see if everything works as expected