### PR TITLE
[EP-3941]: Add prop to Select to disable portalling

### DIFF
--- a/.changeset/little-crabs-provide.md
+++ b/.changeset/little-crabs-provide.md
@@ -1,0 +1,5 @@
+---
+"@igloo-ui/select": minor
+---
+
+Add prop to disable dropdown portal and position options absolutely

--- a/.changeset/little-crabs-provide.md
+++ b/.changeset/little-crabs-provide.md
@@ -2,4 +2,4 @@
 "@igloo-ui/select": minor
 ---
 
-Add prop to disable dropdown portal and position options absolutely
+Added the `disablePortal` prop to disable dropdown portal, positioning options absolutely instead

--- a/packages/Select/src/Select.tsx
+++ b/packages/Select/src/Select.tsx
@@ -55,6 +55,9 @@ export interface SelectProps {
     /** Whether or not to show the icon inside the
    * dropdown list if it's available */
     showListIcon?: boolean;
+    /** Disables the component from appending the dropdown
+   * to the end of the body using ReactPortal */
+    disablePortal?: boolean;
 }
 
 const Select: React.FunctionComponent<SelectProps> = ({
@@ -72,6 +75,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
     options,
     selectedOption,
     showListIcon = true,
+    disablePortal = false,
     ...rest
 }: SelectProps) => {
     const results = React.useMemo(
@@ -290,6 +294,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
                 className={selectDropdownClassname}
                 onClose={() => toggleMenu(true)}
                 isReferenceWidth={!autoWidth}
+                disablePortal={disablePortal}
                 isScrollable
             >
                 <SelectInput isOpen={canShowMenu}>


### PR DESCRIPTION
## What

- Add `disablePortal` prop to `Select` and forward it to the `Dropdown`

## Why

[EP-3941](https://workleap.atlassian.net/browse/EP-3941)

In OV, we are having an intermittent [issue](https://workleap.atlassian.net/browse/EP-1943) where the period select dropdown randomly fails to open.

![no-dropdown](https://github.com/user-attachments/assets/4086ce1c-559c-42c5-b39a-b46bac1bd726)

After much debugging, it appears that the issue is caused by the dropdown floating portal attempting to append the element in a portal with an ID that no longer exists in the DOM, so nothing happens. The underlying reason for why this portal is removed from the DOM is unclear to me, but I suspect is related to [this](https://github.com/facebook/react/issues/24669) issue in React relating to `useId` in a `Suspense`. This is not something we can fix ourselves, but since `Dropdown` supports absolute positioning and `Select` already has `position: relative;` we can just not portal the element for this particular select as a workaround for now, and just need the prop to be passed along to make it happen.

## Other notes:

In case you see a different fix or root cause, here is how I narrowed down the source of the issue to the floating portal: I was able to reproduce the issue locally by refreshing on the Good Vibes page and clicking the dropdown until I see it does not open. In the `node_modules` source code for `Select` I added a mutation observer to the `body` (where elements are portalled to), which watches for node addition/removal and logs when nodes are added/removed as well as the current state of the expected floating portal node in the DOM based upon the ID.

The result:
![image](https://github.com/user-attachments/assets/6f4cdd42-0e0a-4877-bfe4-a8f96daf9157)

We can see the element is created as expected, then is appended and present in the DOM. Then a node with a different ID is removed, but this node also leaves the DOM and becomes null. This only seems to happen when the IDs are 2 characters, but other than that I do not know why this happens.

For reference, here is what is logged when it successfully opens, where we can see the expected node remains in the DOM:
![image](https://github.com/user-attachments/assets/955941c2-a50c-4f72-bb61-294ea684c856)

After testing locally with `disablePortal: true` on the dropdown the select consistently opens, since there is no portal to be missing.