### PR TITLE
Fix dropdown floating portals

### DIFF
--- a/.changeset/tidy-suits-wave.md
+++ b/.changeset/tidy-suits-wave.md
@@ -1,0 +1,11 @@
+---
+"@igloo-ui/area-chart": patch
+"@igloo-ui/dropdown": patch
+"@igloo-ui/popover": patch
+"@igloo-ui/select": patch
+"@igloo-ui/text-editor": patch
+"@igloo-ui/tooltip": patch
+---
+
+- Updated @floating-ui/react to latest to fix issues with FloatingPortal
+- Updated Dropdown, Popover, FloatingLinkEditorPlugin, and Tooltip to render portals only when open

--- a/packages/Dropdown/package.json
+++ b/packages/Dropdown/package.json
@@ -24,7 +24,7 @@
         "build": "rollup -c rollup.config.js"
     },
     "dependencies": {
-        "@floating-ui/react": "^0.26.22",
+        "@floating-ui/react": "^0.27.3",
         "@hopper-ui/tokens": "^4.3.0",
         "@igloo-ui/tokens": "^2.1.0",
         "classnames": "^2.5.1"

--- a/packages/Dropdown/src/Dropdown.tsx
+++ b/packages/Dropdown/src/Dropdown.tsx
@@ -1,20 +1,20 @@
-import * as React from "react";
-import cx from "classnames";
 import {
-    flip,
-    size as fuiSize,
-    useMergeRefs,
-    offset,
-    hide,
     autoUpdate,
-    useFloating,
+    flip,
     FloatingFocusManager,
+    FloatingPortal,
+    size as fuiSize,
+    hide,
+    offset,
     useDismiss,
+    useFloating,
     useInteractions,
-    useTransitionStyles,
+    useMergeRefs,
     useRole,
-    FloatingPortal
+    useTransitionStyles
 } from "@floating-ui/react";
+import cx from "classnames";
+import * as React from "react";
 
 import "./dropdown.scss";
 
@@ -239,6 +239,22 @@ const Dropdown: React.FunctionComponent<DropdownProps> = React.forwardRef(
             }
         }, [isMounted, onAfterClose, dropdownPreviouslyOpen]);
 
+        const renderFloatingElem = (): React.ReactNode => {
+            if (disablePortal) {
+                return floatingElem;
+            }
+
+            if (isMounted) {
+                return (
+                    <FloatingPortal>
+                        {floatingElem}
+                    </FloatingPortal>
+                );
+            }
+
+            return null;
+        };
+
         return (
             <>
                 {renderReference ? (
@@ -252,11 +268,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = React.forwardRef(
                         {children}
                     </div>
                 )}
-                {disablePortal ? (
-                    floatingElem
-                ) : (
-                    <FloatingPortal>{floatingElem}</FloatingPortal>
-                )}
+                {renderFloatingElem()}
             </>
         );
     }

--- a/packages/Dropdown/src/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/Dropdown/src/__snapshots__/Dropdown.test.tsx.snap
@@ -8,12 +8,19 @@ exports[`Dropdown It should render without error and a snapshot 1`] = `
       aria-expanded="true"
       aria-haspopup="listbox"
       class="ids-dropdown__ref"
+      data-floating-ui-inert=""
       role="combobox"
     >
       <button>
         Settings
       </button>
     </div>
+    <span
+      aria-hidden="true"
+      data-floating-ui-inert=""
+      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
+      tabindex="-1"
+    />
     <span
       data-floating-ui-focus-guard=""
       data-type="outside"
@@ -23,6 +30,7 @@ exports[`Dropdown It should render without error and a snapshot 1`] = `
     />
     <span
       aria-owns=":r2:"
+      data-floating-ui-inert=""
       style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
     />
     <span
@@ -46,12 +54,13 @@ exports[`Dropdown It should render without error and a snapshot 1`] = `
     />
     <div
       class="ids-dropdown ids-dropdown--bottom-start"
+      data-floating-ui-focusable=""
       data-show="true"
       data-test="dropdown1"
       id=":r0:"
       role="listbox"
       style="position: fixed; top: 0px; left: 0px; opacity: 0; transform: translateY(1rem);"
-      tabindex="0"
+      tabindex="-1"
     >
       <div
         class="ids-dropdown__scroll-content"

--- a/packages/Popover/package.json
+++ b/packages/Popover/package.json
@@ -31,7 +31,7 @@
     "@igloo-ui/tokens": "^2.1.0",
     "@hopper-ui/tokens": "^4.3.2",
     "classnames": "^2.3.2",
-    "@floating-ui/react": "^0.26.9"
+    "@floating-ui/react": "^0.27.3"
   },
   "browserslist": [
     "> 1%",

--- a/packages/Popover/src/Popover.tsx
+++ b/packages/Popover/src/Popover.tsx
@@ -1,24 +1,23 @@
-import * as React from "react";
-import cx from "classnames";
 import {
-    flip,
-    shift,
-    offset,
-    autoUpdate,
-    useFloating,
-    useDismiss,
-    useInteractions,
-    useTransitionStyles,
     autoPlacement,
-    useRole,
-    FloatingPortal,
-    useClick,
-    useHover,
+    autoUpdate,
+    flip,
     FloatingFocusManager,
+    FloatingPortal,
+    offset,
     safePolygon,
-    type ReferenceType,
+    shift,
+    useClick,
+    useDismiss,
+    useFloating,
+    useHover,
+    useInteractions,
+    useRole,
+    useTransitionStyles,
     type UseHoverProps
 } from "@floating-ui/react";
+import cx from "classnames";
+import * as React from "react";
 
 import IconButton from "@igloo-ui/icon-button";
 import Close from "@igloo-ui/icons/dist/Close";
@@ -117,7 +116,7 @@ const Popover: React.FunctionComponent<PopoverProps> = ({
         ...floatingUIPlacement
     });
 
-    const useHoverProps: UseHoverProps<ReferenceType> = {
+    const useHoverProps: UseHoverProps = {
         enabled: triggerEvent === "hover",
         restMs: 150
     };
@@ -211,8 +210,8 @@ const Popover: React.FunctionComponent<PopoverProps> = ({
             >
                 {children}
             </span>
-            <FloatingPortal>
-                {isMounted && (
+            {isMounted && (
+                <FloatingPortal>
                     <FloatingFocusManager
                         context={context}
                         modal={false}
@@ -220,8 +219,8 @@ const Popover: React.FunctionComponent<PopoverProps> = ({
                     >
                         {popover}
                     </FloatingFocusManager>
-                )}
-            </FloatingPortal>
+                </FloatingPortal>
+            )}
         </>
     );
 };

--- a/packages/Popover/src/__snapshots__/Popover.test.tsx.snap
+++ b/packages/Popover/src/__snapshots__/Popover.test.tsx.snap
@@ -15,10 +15,6 @@ exports[`Popover It should render a snapshot 1`] = `
         popover trigger
       </span>
     </div>
-    <div
-      data-floating-ui-portal=""
-      id=":r2:"
-    />
   </body>,
   "container": <div>
     <span

--- a/packages/TextEditor/package.json
+++ b/packages/TextEditor/package.json
@@ -25,7 +25,7 @@
         "build": "rollup -c rollup.config.js"
     },
     "dependencies": {
-        "@floating-ui/react": "^0.24.8",
+        "@floating-ui/react": "^0.27.3",
         "@igloo-ui/button": "^0.10.0",
         "@igloo-ui/icon-button": "^1.4.0",
         "@igloo-ui/input": "^2.3.2",

--- a/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
+++ b/packages/TextEditor/src/plugins/FloatingLinkEditorPlugin.tsx
@@ -1,21 +1,21 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import * as React from "react";
-import cx from "classnames";
-import { type Dispatch, useCallback, useEffect, useRef, useState } from "react";
 import {
-    flip,
-    shift,
-    offset,
     autoUpdate,
-    useFloating,
-    useDismiss,
-    useInteractions,
-    useTransitionStyles,
-    hide,
+    flip,
+    FloatingFocusManager,
     FloatingPortal,
+    hide,
+    offset,
+    shift,
     useClick,
-    FloatingFocusManager
+    useDismiss,
+    useFloating,
+    useInteractions,
+    useTransitionStyles
 } from "@floating-ui/react";
+import cx from "classnames";
+import * as React from "react";
+import { type Dispatch, useCallback, useEffect, useRef, useState } from "react";
 
 import {
     $isAutoLinkNode,
@@ -38,12 +38,12 @@ import {
 } from "lexical";
 
 import IconButton from "@igloo-ui/icon-button";
-import Input from "@igloo-ui/input";
 import Checkmark from "@igloo-ui/icons/dist/Checkmark";
-import Delete from "@igloo-ui/icons/dist/Delete";
 import Close from "@igloo-ui/icons/dist/Close";
+import Delete from "@igloo-ui/icons/dist/Delete";
 import Edit from "@igloo-ui/icons/dist/Edit";
 import External from "@igloo-ui/icons/dist/Launch";
+import Input from "@igloo-ui/input";
 
 import type { Messages } from "../TextEditor";
 import { getSelectedNode } from "../utils/getSelectedNode";
@@ -335,8 +335,8 @@ function FloatingLinkEditor({
     });
 
     return (
-        <FloatingPortal>
-            {isMounted && (
+        isMounted ? (
+            <FloatingPortal>
                 <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
                     <div
                         ref={refs.setFloating}
@@ -352,8 +352,8 @@ function FloatingLinkEditor({
                         {!isLink ? null : linkEditorHTML}
                     </div>
                 </FloatingFocusManager>
-            )}
-        </FloatingPortal>
+            </FloatingPortal>
+        ) : null
     );
 }
 

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@igloo-ui/tokens": "^2.1.0",
     "@hopper-ui/tokens": "^4.3.2",
-    "@floating-ui/react": "^0.24.8",
+    "@floating-ui/react": "^0.27.3",
     "classnames": "^2.3.2"
   },
   "browserslist": [

--- a/packages/Tooltip/src/Tooltip.test.tsx
+++ b/packages/Tooltip/src/Tooltip.test.tsx
@@ -15,7 +15,7 @@ describe('Tooltip', () => {
   const defaultComponentSetup = {
     children: 'children',
     content: 'tooltip copy',
-    dataTest: 'tooltip-id',
+    dataTest: 'tooltip-id'
   };
 
   test('It should render a snapshot', (): void => {

--- a/packages/Tooltip/src/Tooltip.tsx
+++ b/packages/Tooltip/src/Tooltip.tsx
@@ -1,21 +1,21 @@
-import * as React from "react";
-import cx from "classnames";
 import {
     arrow,
-    flip,
-    shift,
-    offset,
-    autoUpdate,
-    useFloating,
-    useDismiss,
-    useInteractions,
-    useTransitionStyles,
     autoPlacement,
-    useHover,
+    autoUpdate,
+    flip,
+    FloatingPortal,
+    offset,
+    shift,
+    useDismiss,
+    useFloating,
     useFocus,
+    useHover,
+    useInteractions,
     useRole,
-    FloatingPortal
+    useTransitionStyles
 } from "@floating-ui/react";
+import cx from "classnames";
+import * as React from "react";
 
 import useDeviceDetect from "./hooks/useDeviceDetect";
 
@@ -168,8 +168,8 @@ const Tooltip: React.FunctionComponent<TooltipProps> = ({
   return (
       <span ref={refs.setReference} className={classes} {...getReferenceProps()}>
           {children}
-          <FloatingPortal>
-              {isMounted && (
+          {isMounted && (
+              <FloatingPortal>
                   <div
                       ref={refs.setFloating}
                       className={tooltipClasses}
@@ -193,8 +193,8 @@ const Tooltip: React.FunctionComponent<TooltipProps> = ({
                           style={arrowStyles}
                       />
                   </div>
-              )}
-          </FloatingPortal>
+              </FloatingPortal>
+          )}
       </span>
   );
 };

--- a/packages/Tooltip/src/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/Tooltip/src/__snapshots__/Tooltip.test.tsx.snap
@@ -11,10 +11,6 @@ exports[`Tooltip It should render a snapshot 1`] = `
         tooltip
       </span>
     </div>
-    <div
-      data-floating-ui-portal=""
-      id=":r2:"
-    />
   </body>,
   "container": <div>
     <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,13 +1932,6 @@
   resolved "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz"
   integrity sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==
 
-"@floating-ui/core@^1.0.0":
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz"
-  integrity sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==
-  dependencies:
-    "@floating-ui/utils" "^0.2.1"
-
 "@floating-ui/core@^1.4.2":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz"
@@ -1969,76 +1962,43 @@
     "@floating-ui/core" "^1.4.2"
     "@floating-ui/utils" "^0.1.3"
 
-"@floating-ui/dom@^1.6.1":
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz"
-  integrity sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==
-  dependencies:
-    "@floating-ui/core" "^1.0.0"
-    "@floating-ui/utils" "^0.2.0"
-
-"@floating-ui/react-dom@^2.0.0", "@floating-ui/react-dom@^2.0.1":
+"@floating-ui/react-dom@^2.0.0":
   version "2.0.4"
   resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz"
   integrity sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==
   dependencies:
     "@floating-ui/dom" "^1.5.1"
 
-"@floating-ui/react-dom@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz"
-  integrity sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==
-  dependencies:
-    "@floating-ui/dom" "^1.6.1"
-
-"@floating-ui/react-dom@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.1.tgz#cca58b6b04fc92b4c39288252e285e0422291fb0"
-  integrity sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
   dependencies:
     "@floating-ui/dom" "^1.0.0"
 
-"@floating-ui/react@^0.24.8":
-  version "0.24.8"
-  resolved "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz"
-  integrity sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==
+"@floating-ui/react@^0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.3.tgz#f9a30583eddd5770f3a6e1f3479a258f3df0c8c8"
+  integrity sha512-CLHnes3ixIFFKVQDdICjel8muhFLOBdQH7fgtHNPY8UbCNqbeKZ262G7K66lGQOUQWWnYocf7ZbUsLJgGfsLHg==
   dependencies:
-    "@floating-ui/react-dom" "^2.0.1"
-    aria-hidden "^1.2.3"
-    tabbable "^6.0.1"
-
-"@floating-ui/react@^0.26.22":
-  version "0.26.22"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.22.tgz#b46f645f9cd19a591da706aed24608c23cdb89a2"
-  integrity sha512-LNv4azPt8SpT4WW7Kku5JNVjLk2GcS0bGGjFTAgqOONRFo9r/aaGHHPpdiIuQbB1t8shmWyWqTTUDmZ9fcNshg==
-  dependencies:
-    "@floating-ui/react-dom" "^2.1.1"
-    "@floating-ui/utils" "^0.2.7"
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.9"
     tabbable "^6.0.0"
-
-"@floating-ui/react@^0.26.9":
-  version "0.26.9"
-  resolved "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.9.tgz"
-  integrity sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==
-  dependencies:
-    "@floating-ui/react-dom" "^2.0.8"
-    "@floating-ui/utils" "^0.2.1"
-    tabbable "^6.0.1"
 
 "@floating-ui/utils@^0.1.3":
   version "0.1.6"
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz"
-  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
-
 "@floating-ui/utils@^0.2.7":
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.7.tgz#d0ece53ce99ab5a8e37ebdfe5e32452a2bfc073e"
   integrity sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@formatjs/ecma402-abstract@1.17.3":
   version "1.17.3"
@@ -6592,7 +6552,7 @@
   resolved "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz"
   integrity sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==
 
-"@swc/helpers@0.4.14", "legacy-swc-helpers@npm:@swc/helpers@=0.4.14":
+"@swc/helpers@0.4.14":
   version "0.4.14"
   resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz"
   integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
@@ -7953,7 +7913,7 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-hidden@^1.1.1, aria-hidden@^1.2.3:
+aria-hidden@^1.1.1:
   version "1.2.3"
   resolved "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz"
   integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
@@ -14303,6 +14263,13 @@ lazy-universal-dotenv@^4.0.0:
     dotenv "^16.0.0"
     dotenv-expand "^10.0.0"
 
+"legacy-swc-helpers@npm:@swc/helpers@=0.4.14":
+  version "0.4.14"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz"
+  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
+  dependencies:
+    tslib "^2.4.0"
+
 lerna@6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/lerna/-/lerna-6.0.3.tgz"
@@ -19547,7 +19514,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19629,7 +19605,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19981,7 +19964,7 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
-tabbable@^6.0.0, tabbable@^6.0.1:
+tabbable@^6.0.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
@@ -21326,7 +21309,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21339,6 +21322,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What

- Update floating-ui package to latest
- Render FloatingPortals only when they are mounted [per docs](https://floating-ui.com/docs/FloatingPortal#:~:text=Note,not%20in%20use.)

## Why 

[DS-540](https://workleap.atlassian.net/browse/DS-540)
[EP-3989](https://workleap.atlassian.net/browse/EP-3989)

In OV, we have run into an issue where floating portals occasionally do not open. This was thought to be isolated to one component in OV so a workaround was https://github.com/gsoft-inc/ov-igloo-ui/pull/856. This worked for the once case but now that the bug has been seen elsewhere, we would like to fix it for all floating portals to prevent the issue popping back up elsewhere. I believe the latest updates to floating-ui include fixes for the portal IDs that may fix the issue, so updating these packages and then updating our references to igloo should fix the issue.

Thanks @PatrickDeVries for raising the issue and opening the initial PR.

Example of the issue in an ActionMenu:

![image](https://github.com/user-attachments/assets/2b5d3f7f-3476-4823-b015-27b1e31becd8)
