### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,11 +16,11 @@ To get an overview of the project, read the [README](../README.md).
 
 #### Create a new issue
 
-If you spot a problem with the components, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments) on our [issues page](https://github.com/gsoft-inc/ov-igloo-ui/issues). If a related issue doesn't exist, you can [open a new issue](https://github.com/gsoft-inc/ov-igloo-ui/issues/new).
+If you spot a problem with the components, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments) on our [issues page](https://github.com/workleap/ov-igloo-ui/issues). If a related issue doesn't exist, you can [open a new issue](https://github.com/workleap/ov-igloo-ui/issues/new).
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/gsoft-inc/ov-igloo-ui/issues) to find one that interests you. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
+Scan through our [existing issues](https://github.com/workleap/ov-igloo-ui/issues) to find one that interests you. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
 
 ### Make Changes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>Igloo</h1>
 
   <p>Igloo gives a collection of React components for building their products</p>
-  <p><a href="https://github.com/gsoft-inc/ov-igloo-ui/issues/new">Report a Issue</a> . <a href="https://gsoft.slack.com/archives/C02J8004TDK">Ask a Question</a></p>
+  <p><a href="https://github.com/workleap/ov-igloo-ui/issues/new">Report a Issue</a> . <a href="https://gsoft.slack.com/archives/C02J8004TDK">Ask a Question</a></p>
 </div>
 
 ## Documentation
@@ -36,7 +36,7 @@ Before starting make sure [node](https://nodejs.org/en/) and [yarn](https://yarn
 After cloning ov-igloo-ui, run `yarn` to install dependencies.
 
 ```bash
-git clone https://github.com/gsoft-inc/ov-igloo-ui.git
+git clone https://github.com/workleap/ov-igloo-ui.git
 cd ov-igloo-ui
 yarn
 yarn storybook
@@ -55,4 +55,4 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 
 ## License
 
-Copyright © 2019, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2019, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@igloo-ui/monorepo",
   "private": true,
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/ActionMenu/package.json
+++ b/packages/ActionMenu/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Alert/package.json
+++ b/packages/Alert/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "alexandre.beaudoin@gsoft.com"

--- a/packages/AreaChart/package.json
+++ b/packages/AreaChart/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Avatar/package.json
+++ b/packages/Avatar/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/BarChart/package.json
+++ b/packages/BarChart/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Breadcrumb/package.json
+++ b/packages/Breadcrumb/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Button/CHANGELOG.md
+++ b/packages/Button/CHANGELOG.md
@@ -338,15 +338,15 @@
 
 ### Minor Changes
 
-- 76a63cb: - **button:** add loading effect ([2a8d84f](https://github.com/gsoft-inc/ov-igloo-ui/commit/2a8d84fa8739f170e0189d053ec4f5136ad3c4d4))
-  - **button:** add of the responsive view ([364a926](https://github.com/gsoft-inc/ov-igloo-ui/commit/364a92611aae51ab555feaa6e503933ca80f1433))
-  - **button:** classname for OV standard compoliance ([8ed7afb](https://github.com/gsoft-inc/ov-igloo-ui/commit/8ed7afb047f552f52fd151ef2da04be49f9908f1))
-  - **button:** change the css variables name ([68f710d](https://github.com/gsoft-inc/ov-igloo-ui/commit/68f710d16e653681ff90e9124ebbafd759dfe057))
-  - add declaration for `renderContent`  ([5827120](https://github.com/gsoft-inc/ov-igloo-ui/commit/58271200d14a3372dc81fd1d9189e5dfade87143))
-  - add focus state ([31910e4](https://github.com/gsoft-inc/ov-igloo-ui/commit/31910e48ff15d197323666bae376116d6fe97c56))
-  - remove focus when the button is clicked ([caa6d45](https://github.com/gsoft-inc/ov-igloo-ui/commit/caa6d4544979d605794b23b64fdd838af3c61a23))
-  - update stylelint for OV standard compliance ([184d006](https://github.com/gsoft-inc/ov-igloo-ui/commit/184d006ecb10d8b0a19a2303f7399b54b895e992))
-  - configure stylelint ([d27df67](https://github.com/gsoft-inc/ov-igloo-ui/commit/d27df672a99145eb3a134cab4549b0e0998a6d0f))
+- 76a63cb: - **button:** add loading effect ([2a8d84f](https://github.com/workleap/ov-igloo-ui/commit/2a8d84fa8739f170e0189d053ec4f5136ad3c4d4))
+  - **button:** add of the responsive view ([364a926](https://github.com/workleap/ov-igloo-ui/commit/364a92611aae51ab555feaa6e503933ca80f1433))
+  - **button:** classname for OV standard compoliance ([8ed7afb](https://github.com/workleap/ov-igloo-ui/commit/8ed7afb047f552f52fd151ef2da04be49f9908f1))
+  - **button:** change the css variables name ([68f710d](https://github.com/workleap/ov-igloo-ui/commit/68f710d16e653681ff90e9124ebbafd759dfe057))
+  - add declaration for `renderContent`  ([5827120](https://github.com/workleap/ov-igloo-ui/commit/58271200d14a3372dc81fd1d9189e5dfade87143))
+  - add focus state ([31910e4](https://github.com/workleap/ov-igloo-ui/commit/31910e48ff15d197323666bae376116d6fe97c56))
+  - remove focus when the button is clicked ([caa6d45](https://github.com/workleap/ov-igloo-ui/commit/caa6d4544979d605794b23b64fdd838af3c61a23))
+  - update stylelint for OV standard compliance ([184d006](https://github.com/workleap/ov-igloo-ui/commit/184d006ecb10d8b0a19a2303f7399b54b895e992))
+  - configure stylelint ([d27df67](https://github.com/workleap/ov-igloo-ui/commit/d27df672a99145eb3a134cab4549b0e0998a6d0f))
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
@@ -355,15 +355,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- add declaration for `renderContent`  ([5827120](https://github.com/gsoft-inc/ov-igloo-ui/commit/58271200d14a3372dc81fd1d9189e5dfade87143))
-- **button:** classname for OV standard compoliance ([8ed7afb](https://github.com/gsoft-inc/ov-igloo-ui/commit/8ed7afb047f552f52fd151ef2da04be49f9908f1))
-- remove focus when the button is clicked ([caa6d45](https://github.com/gsoft-inc/ov-igloo-ui/commit/caa6d4544979d605794b23b64fdd838af3c61a23))
-- configure stylelint ([d27df67](https://github.com/gsoft-inc/ov-igloo-ui/commit/d27df672a99145eb3a134cab4549b0e0998a6d0f))
-- update stylelint for OV standard compliance ([184d006](https://github.com/gsoft-inc/ov-igloo-ui/commit/184d006ecb10d8b0a19a2303f7399b54b895e992))
+- add declaration for `renderContent`  ([5827120](https://github.com/workleap/ov-igloo-ui/commit/58271200d14a3372dc81fd1d9189e5dfade87143))
+- **button:** classname for OV standard compoliance ([8ed7afb](https://github.com/workleap/ov-igloo-ui/commit/8ed7afb047f552f52fd151ef2da04be49f9908f1))
+- remove focus when the button is clicked ([caa6d45](https://github.com/workleap/ov-igloo-ui/commit/caa6d4544979d605794b23b64fdd838af3c61a23))
+- configure stylelint ([d27df67](https://github.com/workleap/ov-igloo-ui/commit/d27df672a99145eb3a134cab4549b0e0998a6d0f))
+- update stylelint for OV standard compliance ([184d006](https://github.com/workleap/ov-igloo-ui/commit/184d006ecb10d8b0a19a2303f7399b54b895e992))
 
 ### Features
 
-- add focus state ([31910e4](https://github.com/gsoft-inc/ov-igloo-ui/commit/31910e48ff15d197323666bae376116d6fe97c56))
-- **button:** add loading effect ([2a8d84f](https://github.com/gsoft-inc/ov-igloo-ui/commit/2a8d84fa8739f170e0189d053ec4f5136ad3c4d4))
-- **button:** add of the responsive view ([364a926](https://github.com/gsoft-inc/ov-igloo-ui/commit/364a92611aae51ab555feaa6e503933ca80f1433))
-- **button:** change the css variables name ([68f710d](https://github.com/gsoft-inc/ov-igloo-ui/commit/68f710d16e653681ff90e9124ebbafd759dfe057))
+- add focus state ([31910e4](https://github.com/workleap/ov-igloo-ui/commit/31910e48ff15d197323666bae376116d6fe97c56))
+- **button:** add loading effect ([2a8d84f](https://github.com/workleap/ov-igloo-ui/commit/2a8d84fa8739f170e0189d053ec4f5136ad3c4d4))
+- **button:** add of the responsive view ([364a926](https://github.com/workleap/ov-igloo-ui/commit/364a92611aae51ab555feaa6e503933ca80f1433))
+- **button:** change the css variables name ([68f710d](https://github.com/workleap/ov-igloo-ui/commit/68f710d16e653681ff90e9124ebbafd759dfe057))

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/ButtonGroup/package.json
+++ b/packages/ButtonGroup/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Card/package.json
+++ b/packages/Card/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Carousel/package.json
+++ b/packages/Carousel/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Franck franck.gaudin@gsoft.com"

--- a/packages/Color/package.json
+++ b/packages/Color/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/ColorPicker/package.json
+++ b/packages/ColorPicker/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Combobox/package.json
+++ b/packages/Combobox/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Datepicker/package.json
+++ b/packages/Datepicker/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Dialog/package.json
+++ b/packages/Dialog/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Disclosure/package.json
+++ b/packages/Disclosure/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Dropdown/package.json
+++ b/packages/Dropdown/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Franck franck.gaudin@gsoft.com"

--- a/packages/Ellipsis/package.json
+++ b/packages/Ellipsis/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Sylvester sylvester.vuong@gsoft.com"

--- a/packages/Filter/package.json
+++ b/packages/Filter/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/FormGroup/package.json
+++ b/packages/FormGroup/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/HelperText/package.json
+++ b/packages/HelperText/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Franck franck.gaudin@gsoft.com"

--- a/packages/Hyperlink/package.json
+++ b/packages/Hyperlink/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com",

--- a/packages/IconButton/package.json
+++ b/packages/IconButton/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "sylvester.vuong@gsoft.com"

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Sylvester sylvester.vuong@gsoft.com"

--- a/packages/List/package.json
+++ b/packages/List/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Metric/package.json
+++ b/packages/Metric/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Modal/package.json
+++ b/packages/Modal/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Franck franck.gaudin@gsoft.com"

--- a/packages/OptionButton/package.json
+++ b/packages/OptionButton/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Pager/package.json
+++ b/packages/Pager/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/PieChart/package.json
+++ b/packages/PieChart/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Popover/package.json
+++ b/packages/Popover/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/ProgressBar/package.json
+++ b/packages/ProgressBar/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Franck franck.gaudin@gsoft.com"

--- a/packages/Provider/package.json
+++ b/packages/Provider/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@workleap.com"

--- a/packages/Radio/package.json
+++ b/packages/Radio/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Select/package.json
+++ b/packages/Select/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "alexandre.beaudoin@gsoft.com"

--- a/packages/StackedBar/package.json
+++ b/packages/StackedBar/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Stepper/package.json
+++ b/packages/Stepper/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.coemau@gsoft.com"

--- a/packages/Tabs/package.json
+++ b/packages/Tabs/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Tag/package.json
+++ b/packages/Tag/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/TagPicker/package.json
+++ b/packages/TagPicker/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/TextEditor/package.json
+++ b/packages/TextEditor/package.json
@@ -8,7 +8,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+    "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
     "author": "Officevibe Inc.",
     "contributors": [
         "Vicky Comeau vicky.comeau@gsoft.com"

--- a/packages/Textarea/package.json
+++ b/packages/Textarea/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky vicky.comeau@gsoft.com"

--- a/packages/Toaster/package.json
+++ b/packages/Toaster/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Toggle/package.json
+++ b/packages/Toggle/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com"

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Franck franck.gaudin@gsoft.com",

--- a/packages/VerticalBarChart/package.json
+++ b/packages/VerticalBarChart/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "Vicky Comeau vicky.comeau@gsoft.com"

--- a/shared/components/package.json
+++ b/shared/components/package.json
@@ -6,7 +6,7 @@
   "module": "dist/Index.js",
   "types": "dist/Index.d.ts",
   "styles": "dist/index.css",
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [
     "franck.gaudin@gsoft.com"

--- a/utils/bootstrap/template/package.json
+++ b/utils/bootstrap/template/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "git+https://github.com/gsoft-inc/ov-igloo-ui.git",
+  "repository": "git+https://github.com/workleap/ov-igloo-ui.git",
   "author": "Officevibe Inc.",
   "contributors": [],
   "license": "Apache-2.0",

--- a/website/components/Layout.js
+++ b/website/components/Layout.js
@@ -12,7 +12,7 @@ import darkMode from '../svg/dark-mode.svg';
 export default function Layout({ children, page }) {
   const externalLink = [
     {
-      href: 'https://github.com/gsoft-inc/ov-igloo-ui',
+      href: 'https://github.com/workleap/ov-igloo-ui',
       icon: github,
       label: 'GitHub',
     },

--- a/website/components/ReferenceLinks.js
+++ b/website/components/ReferenceLinks.js
@@ -12,7 +12,7 @@ export default function ReferenceLinks({ component, version }) {
           <a
             className="reference__link"
             target="_blank"
-            href={`https://github.com/gsoft-inc/ov-igloo-ui/tree/main/packages/${component}`}
+            href={`https://github.com/workleap/ov-igloo-ui/tree/main/packages/${component}`}
           >
             View source
           </a>
@@ -31,7 +31,7 @@ export default function ReferenceLinks({ component, version }) {
           <a
             className="reference__link"
             target="_blank"
-            href={`https://github.com/gsoft-inc/ov-igloo-ui/issues/new?title=${component}`}
+            href={`https://github.com/workleap/ov-igloo-ui/issues/new?title=${component}`}
           >
             Report an Issue
           </a>

--- a/website/pages/component/getting-started.js
+++ b/website/pages/component/getting-started.js
@@ -72,7 +72,7 @@ export default function GettingStarted(props) {
                   <p>
                     After cloning{' '}
                     <a
-                      href="https://github.com/gsoft-inc/ov-igloo-ui"
+                      href="https://github.com/workleap/ov-igloo-ui"
                       target="_blank"
                     >
                       ov-igloo-ui

--- a/website/pages/icons.js
+++ b/website/pages/icons.js
@@ -83,7 +83,7 @@ export default function Icons() {
         <p>
           Not finding an icon that you want?{' '}
           <a
-            href="https://github.com/gsoft-inc/ov-igloo-icons/issues/new"
+            href="https://github.com/workleap/ov-igloo-icons/issues/new"
             target="_blank"
           >
             File an issue

--- a/website/pages/index.js
+++ b/website/pages/index.js
@@ -61,7 +61,7 @@ export default function Home() {
             icon={<Image src={issue} />}
             title="Report an Issue"
             description="Submit comments or feature requests to grow Igloo"
-            link="https://github.com/gsoft-inc/ov-igloo-ui/issues/new/choose"
+            link="https://github.com/workleap/ov-igloo-ui/issues/new/choose"
             inline
           />
         </div>

--- a/website/pages/tokens.js
+++ b/website/pages/tokens.js
@@ -164,7 +164,7 @@ export default function Tokens(props) {
 export async function getStaticProps() {
   const fetcher = (path) =>
     fetch(
-      `https://raw.githubusercontent.com/gsoft-inc/ov-igloo-tokens/main${path}`
+      `https://raw.githubusercontent.com/workleap/ov-igloo-tokens/main${path}`
     ).then((res) => res.json());
 
   const tokens = await fetcher('/docs/tokens.json');


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 